### PR TITLE
HTML encode test errors to generate valid XML always

### DIFF
--- a/src/ParaTest/Logging/JUnit/Writer.php
+++ b/src/ParaTest/Logging/JUnit/Writer.php
@@ -152,7 +152,7 @@ class Writer
     protected function appendDefects($caseNode, $defects, $type)
     {
         foreach ($defects as $defect) {
-            $defectNode = $this->document->createElement($type, htmlentities($defect['text']) . "\n");
+            $defectNode = $this->document->createElement($type, htmlspecialchars($defect['text'], ENT_XML1) . "\n");
             $defectNode->setAttribute('type', $defect['type']);
             $caseNode->appendChild($defectNode);
         }


### PR DESCRIPTION


PR https://github.com/brianium/paratest/pull/127 started escaping all HTML entities in order to produce valid JUnit XML. However, this is problematic because it escapes characters like `—` (`&mdash;`) and `…` (`&hellip;`) get escaped and produce invalid XML due to the `&` character.

Switching to `htmlspecialchars` ensures that only intended characters are escaped.


Upstream patch: https://github.com/brianium/paratest/pull/296
