### PR TITLE
Add logging to the test runner 

### DIFF
--- a/bin/phpunit-wrapper
+++ b/bin/phpunit-wrapper
@@ -13,7 +13,23 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
 
 $commands = fopen('php://stdin', 'r');
 $lastExitCode = 0;
+
+$rand = rand ( 0 , 999999 );
+$uniqueTestToken = getenv("UNIQUE_TEST_TOKEN") ?: "no_unique_test_token";
+$testToken = getenv("TEST_TOKEN") ?: "no_test_token";
+$filename = "paratest_t-{$testToken}_ut-{$uniqueTestToken}_r-{$rand}.log";
+$path = sys_get_temp_dir()."/".$filename;
+$loggingEnabled = getenv("PT_LOGGING_ENABLE");
+$logInfo = function(string $info) use ($path, $loggingEnabled){
+    if(!$loggingEnabled){
+        return;
+    }
+    file_put_contents($path, $info, FILE_APPEND | LOCK_EX);
+};
+
+$i = 0;
 while (true) {
+    $i++;
     if (feof($commands)) {
         exit($lastExitCode);
     }
@@ -28,11 +44,23 @@ while (true) {
     }
     echo "Executing: $command\n";
 
+    $info = [];
+    $info[] = "Time: ".(new \DateTime())->format(DateTime::RFC3339);
+    $info[] = "Iteration: $i";
+    $info[] = "Command: $command";
+    $info[] = PHP_EOL;
+    $infoText = implode(PHP_EOL,$info).PHP_EOL;
+    $logInfo($infoText);
+
     if (!preg_match_all('/\'([^\']*)\'[ ]?/', $command, $arguments)) {
         throw new \Exception("Failed to parse arguments from command line: \"" . $command . "\"");
     }
     $_SERVER['argv'] = $arguments[1];
 
+    ob_start();
     $lastExitCode = PHPUnit_TextUI_Command::main(false);
+    $infoText = ob_get_clean();
+    $logInfo($infoText);
+
     echo "FINISHED\n";
 }


### PR DESCRIPTION
The paratest docs mention logging, but our branch is far behind master and so doesn't support this. https://github.com/paratestphp/paratest/blob/master/docs/logging.md

This PR enables logging by copy/pasting the relevant lines from https://github.com/paratestphp/paratest/blob/master/bin/phpunit-wrapper

Then, to see the logs you can `cd /tmp; tail -f paratest*`

I'll update the unit test troubleshooting docs to include this once it's merged and this version is used in quizlet-web. 